### PR TITLE
♻️ refactor: Profile 컴포넌트 div 최소화,  아웃라인 반영

### DIFF
--- a/src/component/common/BigProfile/FollowCounter/index.jsx
+++ b/src/component/common/BigProfile/FollowCounter/index.jsx
@@ -22,7 +22,7 @@ const StyledP = styled.p`
   color: ${({ theme }) => theme.snGreyIcon};
 `;
 
-export default function FollowCounter() {
+function FollowerCounter() {
   return (
     <Wrapper>
       <Count>295</Count>
@@ -30,3 +30,14 @@ export default function FollowCounter() {
     </Wrapper>
   );
 }
+
+function FollowingCounter() {
+  return (
+    <Wrapper>
+      <Count>300</Count>
+      <StyledP>followings</StyledP>
+    </Wrapper>
+  );
+}
+
+export { FollowerCounter, FollowingCounter };

--- a/src/component/common/BigProfile/index.jsx
+++ b/src/component/common/BigProfile/index.jsx
@@ -43,9 +43,11 @@ const Img = styled.img`
   ${({ isPhotographer }) =>
     isPhotographer &&
     css`
-      outline: ${({ theme }) => theme.snBlue} solid 4px;
-      outline-offset: -4px;
+      outline: ${({ theme }) => theme.snBlue} solid 6px;
+      outline-offset: -6px;
     `}
+
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
 `;
 
 export default function BigProfile({ bottomRight, left, right, ...props }) {

--- a/src/component/common/BigProfile/index.jsx
+++ b/src/component/common/BigProfile/index.jsx
@@ -39,15 +39,28 @@ const Img = styled.img`
   vertical-align: top;
 
   flex-shrink: 0;
+
+  ${({ isPhotographer }) =>
+    isPhotographer &&
+    css`
+      outline: ${({ theme }) => theme.snBlue} solid 4px;
+      outline-offset: -4px;
+    `}
 `;
 
-export default function BigProfile({ bottomRight, left, right }) {
+export default function BigProfile({ bottomRight, left, right, ...props }) {
+  const { isPhotographer } = props;
+
   if (process.env.NODE_ENV === "development") {
     return (
       <Wrapper bottomRight={bottomRight}>
         {left}
         <div className="image-wrapper">
-          <Img src={"https://fakeimg.pl/110x110/"} alt="프로필 이미지입니다" />
+          <Img
+            src={"https://fakeimg.pl/110x110/"}
+            alt="프로필 이미지입니다"
+            isPhotographer={isPhotographer}
+          />
           <div className="bottom-right-wrapper">{bottomRight}</div>
         </div>
         {right}
@@ -59,7 +72,11 @@ export default function BigProfile({ bottomRight, left, right }) {
     <Wrapper bottomRight={bottomRight}>
       {left}
       <div className="image-wrapper">
-        <Img src={""} alt="프로필 이미지입니다" />
+        <Img
+          src={"https://fakeimg.pl/110x110/"}
+          alt="프로필 이미지입니다"
+          isPhotographer={isPhotographer}
+        />
         <div className="bottom-right-wrapper">{bottomRight}</div>
       </div>
       {right}
@@ -71,4 +88,5 @@ BigProfile.propTypes = {
   left: PropTypes.node,
   right: PropTypes.node,
   bottomRight: PropTypes.element,
+  isPhotographer: PropTypes.bool,
 };

--- a/src/component/common/SmallProfile/Side/Title/index.jsx
+++ b/src/component/common/SmallProfile/Side/Title/index.jsx
@@ -20,7 +20,7 @@ const Wrapper = styled.div`
     font-size: ${FONT_SIZE.MEDIUM};
     line-height: 14px;
 
-    color: ${({ theme }) => theme.snGrayIcon};
+    color: ${({ theme }) => theme.snGreyIcon};
 
     overflow: hidden;
     text-overflow: ellipsis;
@@ -40,7 +40,7 @@ const StyledTitle = styled.strong`
     font-size: ${FONT_SIZE.SMALL};
     line-height: 13px;
 
-    color: ${({ theme }) => theme.snGrayIcon};
+    color: ${({ theme }) => theme.snGreyIcon};
 
     ::before {
       content: "\\00B7";

--- a/src/component/common/SmallProfile/Side/index.jsx
+++ b/src/component/common/SmallProfile/Side/index.jsx
@@ -10,6 +10,10 @@ const Wrapper = styled.div`
   justify-content: space-between;
   align-items: center;
   gap: 12px;
+
+  & * + * {
+    flex-shrink: 0;
+  }
 `;
 
 export default function Side({ left, right }) {

--- a/src/component/common/SmallProfile/Side/index.jsx
+++ b/src/component/common/SmallProfile/Side/index.jsx
@@ -9,9 +9,7 @@ const Wrapper = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 20px;
-
-  padding: 0 12px;
+  gap: 12px;
 `;
 
 export default function Side({ left, right }) {

--- a/src/component/common/SmallProfile/index.jsx
+++ b/src/component/common/SmallProfile/index.jsx
@@ -27,6 +27,7 @@ const Wrapper = styled.div`
         top: 0;
         left: 0;
         z-index: 10;
+        outline: ${({ theme }) => theme.snWhite} 1px solid;
       }
     `}
 `;
@@ -41,8 +42,8 @@ const Img = styled.img`
   ${({ isPhotographer }) =>
     isPhotographer &&
     css`
-      outline: ${({ theme }) => theme.snBlue} solid 2px;
-      outline-offset: -2px;
+      outline: ${({ theme }) => theme.snBlue} solid 3px;
+      outline-offset: -3px;
     `}
 `;
 

--- a/src/component/common/SmallProfile/index.jsx
+++ b/src/component/common/SmallProfile/index.jsx
@@ -9,25 +9,26 @@ const Wrapper = styled.div`
   display: flex;
   align-items: center;
   position: relative;
+  gap: 12px;
 
   width: 100%;
 
   ${({ isNotifying }) =>
-    isNotifying
-    && css`
-          &::before {
-            content: "";
-            display: block;
-            width: 12px;
-            height: 12px;
-            border-radius: 50%;
-            background-color: ${({ theme }) => theme.snBlue};
-            position: absolute;
-            top: 0;
-            left: 0;
-            z-index: 10;
-          }
-        `}
+    isNotifying &&
+    css`
+      &::before {
+        content: "";
+        display: block;
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        background-color: ${({ theme }) => theme.snBlue};
+        position: absolute;
+        top: 0;
+        left: 0;
+        z-index: 10;
+      }
+    `}
 `;
 
 const Img = styled.img`
@@ -36,6 +37,13 @@ const Img = styled.img`
   position: relative;
 
   ${({ size }) => sizeStyleMap[size] ?? ""}
+
+  ${({ isPhotographer }) =>
+    isPhotographer &&
+    css`
+      outline: ${({ theme }) => theme.snBlue} solid 2px;
+      outline-offset: -2px;
+    `}
 `;
 
 const sizeStyleMap = {
@@ -56,23 +64,46 @@ const sizeStyleMap = {
 /**
  * `isNotifying` : 채팅 페이지에서 사용시 노티 표시 여부
  */
-export default function SmallProfile({ size, isNotifying, children }) {
-  if (process.env.NODE_ENV === "development") { // TODO: 개발 모드 추후 삭제 필요
-    return (
+export default function SmallProfile({ size, children, ...props }) {
+  const { isPhotographer, isNotifying } = props;
+
+  if (process.env.NODE_ENV === "development") {
+    // TODO: 개발 모드 추후 삭제 필요
+    return !children ? (
+      <Img
+        src={"https://fakeimg.pl/110x110/"}
+        alt="프로필 이미지입니다"
+        size={size}
+        isPhotographer={isPhotographer}
+      />
+    ) : (
       <Wrapper isNotifying={isNotifying}>
         <Img
           src={"https://fakeimg.pl/110x110/"}
           alt="프로필 이미지입니다"
           size={size}
+          isPhotographer={isPhotographer}
         />
         {children}
       </Wrapper>
     );
   }
 
-  return (
+  return !children ? (
+    <Img
+      src={"https://fakeimg.pl/110x110/"}
+      alt="프로필 이미지입니다"
+      size={size}
+      isPhotographer={isPhotographer}
+    />
+  ) : (
     <Wrapper isNotifying={isNotifying}>
-      <Img src="" alt="프로필 이미지입니다" size={size} />
+      <Img
+        src={"https://fakeimg.pl/110x110/"}
+        alt="프로필 이미지입니다"
+        size={size}
+        isPhotographer={isPhotographer}
+      />
       {children}
     </Wrapper>
   );
@@ -82,6 +113,7 @@ SmallProfile.propTypes = {
   size: PropTypes.oneOf(Object.values(PROFILE_SIZE)).isRequired,
   isNotifying: PropTypes.bool,
   children: PropTypes.node,
+  isPhotographer: PropTypes.bool,
 };
 
 SmallProfile.Side = Side;


### PR DESCRIPTION
### ▪️ 무엇을 위한 PR인가요?

- 리팩토링 : Profile 컴포넌트 div 최소화,  아웃라인 반영

### ▪️ 기대 결과

- 프로필 이미지만 렌더링하기 원할 시 div 없이 이미지 요소만 렌더링
- props중 isPhotographer를 true로 줄 시 파란색 아웃라인 반영

### ▪️ 전달사항

- BigProfile은 여전히 div가 존재해도 상관 없을 것이라고 판단
- SmallProfile.Side의 title과 subtitle간의 간격은 상황에 따라 스타일 덮어쓰기로 변경해주어야 함
- snGrayIcon -> snGreyIcon 으로 바꿔주어야하는 문제가 두 곳정도 있음 (프로필컴포넌트에서는 완료)

```jsx
return (
    <Wrapper>
      <GlobalStyle />
      <ThemeProvider theme={theme}>
        <BigProfile
          left={<FollowerCounter />}
          right={<FollowingCounter />}
          bottomRight={<button type="button">업로드</button>}
          isPhotographer={true}
        />

        <SmallProfile
          size={PROFILE_SIZE.SMALL}
          isNotifying={true}
          isPhotographer={true}
        />
      </ThemeProvider>
    </Wrapper>
  );
```

### ▪️ Issue Number

close : # 11
