### PR TITLE
🎨 style: AlertModal Button 개수에 따른 대응

### DIFF
--- a/src/component/common/AlertModal/index.jsx
+++ b/src/component/common/AlertModal/index.jsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import PropTypes from "prop-types";
 
 import Button from "./Button/index";
@@ -8,16 +8,26 @@ const Wrapper = styled.div`
   width: 252px;
   background: ${({ theme }) => theme.snGreyOff};
   border-radius: 10px;
+
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(${({ children }) => children.length - 1}, 1fr);
   grid-template-rows: minmax(64px, auto) 46px;
-  gap: 1px;
-  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  gap: 1px 0px;
+  ${({ children }) =>
+    children.length >= 3 &&
+    css`
+      gap: 1px 1px;
+    `}
+
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.25);
   overflow: hidden;
+
+  & *:first-child {
+    grid-column: 1 / ${({ children }) => children.length};
+  }
 `;
 
 const Content = styled.p`
-  grid-column: 1 / 3;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -31,18 +41,14 @@ const Content = styled.p`
 `;
 
 export default function AlertModal({ isModalOpened, children }) {
-  return (isModalOpened &&
-    <Wrapper>
-      {children}
-    </Wrapper>
-  );
+  return isModalOpened && <Wrapper>{children}</Wrapper>;
 }
 
 AlertModal.Content = Content;
 AlertModal.CancleButton = Button;
 AlertModal.ConfirmButton = styled(Button)`
   color: ${({ theme }) => theme.snBlue};
-`
+`;
 
 AlertModal.propTypes = {
   isModalOpened: PropTypes.bool,


### PR DESCRIPTION
### ▪️ 무엇을 위한 PR인가요?

- 스타일 : AlertModal Button 개수에 따른 대응

### ▪️ 기대 결과

- alert modal의 버튼이 1개일 때도 정상적으로 보이도록 스타일 수정

### ▪️ 전달사항

- 버튼은 2개까지 들어가는 게 좋음

### ▪️ Issue Number

close : #15 
