### PR TITLE
🎨 style: SmallProfile.Side.Title에서 title과 subtitle간의 간격 대응

### DIFF
--- a/src/component/common/SmallProfile/Side/Title/index.jsx
+++ b/src/component/common/SmallProfile/Side/Title/index.jsx
@@ -13,7 +13,7 @@ const Wrapper = styled.div`
   }
 
   .subtitle {
-    margin-top: 2px;
+    margin-top: ${({ gap }) => gap + "px"};
     width: 100%;
 
     font-weight: 400;
@@ -49,9 +49,17 @@ const StyledTitle = styled.strong`
   }
 `;
 
-export default function Title({ title, subtitle, attachment }) {
+/**
+ * SmallProfile.Side의 왼쪽 부분을 담당하는 컴포넌트
+ *
+ * @prop {string} title
+ * @prop {string} subtitle
+ * @prop {element} attachment
+ * @prop {number} gap title과 subtitle간의 간격을 의미
+ */
+export default function Title({ title, subtitle, attachment, gap = 2 }) {
   return (
-    <Wrapper>
+    <Wrapper gap={gap}>
       <div className="title-wrapper">
         <StyledTitle>{title}</StyledTitle>
         {!!attachment && attachment}
@@ -65,4 +73,5 @@ Title.propTypes = {
   title: PropTypes.string,
   subtitle: PropTypes.string,
   attachment: PropTypes.element,
+  gap: PropTypes.number,
 };


### PR DESCRIPTION
### ▪️ 무엇을 위한 PR인가요?

- 스타일 : SmallProfile.Side.Title에서 title과 subtitle간의 간격 대응

### ▪️ 기대 결과

- 상황에 따라 SmallProfile.Side.Title에서 title과 subtitle간의 간격을 조절해야하는데 각자가 스타일링으로 해결하기엔 복잡하다고 판단
- SmallProfile.Side.Title의 prop으로 gap={숫자}를 넘겨줄 시 title과 subtitle 간의 간격 조절 가능
- 기본 간격은 2px로 지정되어있음

### ▪️ 전달사항

```jsx
<SmallProfile size={PROFILE_SIZE.MEDIUM}>
  <SmallProfile.Side
    left={
      <SmallProfile.Side.Title title="hi" subtitle="hello" gap={6} />
    }
</SmallProfile>
```

### ▪️ Issue Number

close : #11
