### PR TITLE
♻️ refactor: useValidationInput 리턴 배열로 변경 및 flag 리턴 추가

### DIFF
--- a/src/hook/useValidationInput.js
+++ b/src/hook/useValidationInput.js
@@ -1,16 +1,24 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 
-export default function useValidationInput({ checkValidation }) {
+/**
+ * ValidationInput 사용을 위한 Custom Hook
+ *
+ * @param {(value:string) => string | null} checkValidation
+ * @returns {[inputRef: React.MutableRefObject<HTMLInputElement>, handleValidation: () => void, errorMessage: string, isPassed: boolean]}
+ */
+export default function useValidationInput(checkValidation) {
   const inputRef = useRef(null);
   const errorMessageCache = useRef("");
   const [errorMessage, setErrorMessage] = useState("");
+  const [isPassed, setIsPassed] = useState(false);
 
   const handleValidation = useCallback(() => {
     const {
       current: { value },
     } = inputRef;
 
-    const errorMessageCalculated = checkValidation(value);
+    const errorMessageCalculated = checkValidation(value) || "";
+    setIsPassed(!errorMessageCalculated);
 
     setErrorMessage(errorMessageCalculated);
     errorMessageCache.current = errorMessageCalculated;
@@ -40,5 +48,5 @@ export default function useValidationInput({ checkValidation }) {
     }
   }, [addFocusListeners, removeFocusListeners]);
 
-  return { inputRef, handleValidation, errorMessage };
+  return [inputRef, handleValidation, errorMessage, isPassed];
 }


### PR DESCRIPTION
### ▪️ 무엇을 위한 PR인가요?

- [x] 리팩토링 : useValidationInput 리턴 변경

### ▪️ 기대 결과

- 리턴값을 배열로 줘서 여러 input을 사용해도 네이밍 충돌이 일어나지 않도록 합니다.

### ▪️ 전달사항

- 사용 방법이 변경됐습니다. 아래의 예시 코드를 확인해주세요.
```jsx
import ValidationInputWrapper from "component/common/Input/ValidationInput";
import useValidationInput from "hook/useValidationInput";

export default function HomePage() {
  const checkValidation = (text) => {
    return text.length > 6 ? "" : "6자보다 커야 합니다.";
  };

  /* 이제 isPassed로 통과 여부를 나타내는 boolean을 줍니다. */
  const [inputRef, handleValidation, errorMessage, isPassed] = useValidationInput(
    checkValidation,
  );

  return (
    <ValidationInputWrapper errorMessage={errorMessage}>
      <ValidationInputWrapper.Input
        ref={inputRef}
        labelText="로그인"
        onChange={() => handleValidation()}
      />
      <ValidationInputWrapper.ErrorMessage />
    </ValidationInputWrapper>
  );
}
```
