### PR TITLE
♻️ chore: Button 컴포넌트 사용법 변경 및 상수 변경

### DIFF
--- a/src/component/common/Button/index.jsx
+++ b/src/component/common/Button/index.jsx
@@ -1,9 +1,11 @@
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 import PropTypes from "prop-types";
 
 import { BUTTON_SIZE } from "constant/size";
 import { BUTTON_STATE } from "constant/button_state";
 import { FONT_SIZE } from "constant/style";
+
+import { sizeStyleMap, stateStyleMap } from "./style";
 
 const StyledButton = styled.button`
   display: inline-block;
@@ -16,63 +18,22 @@ const StyledButton = styled.button`
   ${({ size }) => sizeStyleMap[size] ?? ""}
 `;
 
-const stateStyleMap = {
-  disabled: css`
-    background-color: ${({ theme }) => theme.snDisabled};
-    pointer-events: none;
-  `,
-  activated: css`
-    background-color: ${({ theme }) => theme.snWhite};
-    color: ${({ theme }) => theme.snGreyIcon};
-  `,
-};
-
-const sizeStyleMap = {
-  xs: css`
-    width: 56px;
-    height: 28px;
-    border-radius: 26px;
-  `,
-  sm: css`
-    width: 90px;
-    height: 32px;
-    border-radius: 26px;
-  `,
-  md: css`
-    width: 100px;
-    height: 34px;
-    border-radius: 32px;
-  `,
-  lg34: css`
-    width: 120px;
-    height: 34px;
-    border-radius: 30px;
-  `,
-  lg44: css`
-    width: 120px;
-    height: 44px;
-    border-radius: 44px;
-  `,
-  xl: css`
-    width: 322px;
-    height: 44px;
-    border-radius: 44px;
-  `,
-};
-
-Button.propTypes = {
-  size: PropTypes.oneOf(Object.values(BUTTON_SIZE)).isRequired,
-  state: PropTypes.oneOf(Object.values(BUTTON_STATE)).isRequired,
-  children: PropTypes.string.isRequired,
-  callbacks: PropTypes.object.isRequired,
-};
-
-export default function Button({ ...props }) {
-  const { size, state, children, callbacks } = props;
-
+/**
+ * 
+ * @param {{ size: BUTTON_SIZE, state: BUTTON_STATE, children: import("react").ReactNode, ...props }} params
+ * 
+ * @returns 
+ */
+export default function Button({ size, state, children, ...props }) {
   return (
-    <StyledButton size={size} state={state} onClick={callbacks[state]}>
+    <StyledButton size={size} state={state} {...props}>
       {children}
     </StyledButton>
   );
 }
+
+Button.propTypes = {
+  size: PropTypes.oneOf(Object.values(BUTTON_SIZE)).isRequired,
+  state: PropTypes.oneOf(Object.values(BUTTON_STATE.LARGE_34)).isRequired,
+  children: PropTypes.string.isRequired,
+};

--- a/src/component/common/Button/index.jsx
+++ b/src/component/common/Button/index.jsx
@@ -7,7 +7,7 @@ import { FONT_SIZE } from "constant/style";
 
 import { sizeStyleMap, stateStyleMap } from "./style";
 
-const StyledButton = styled.button`
+const Button = styled.button`
   display: inline-block;
   color: ${({ theme }) => theme.snWhite};
   font-size: ${FONT_SIZE.BASE};
@@ -18,22 +18,10 @@ const StyledButton = styled.button`
   ${({ size }) => sizeStyleMap[size] ?? ""}
 `;
 
-/**
- * 
- * @param {{ size: BUTTON_SIZE, state: BUTTON_STATE, children: import("react").ReactNode, ...props }} params
- * 
- * @returns 
- */
-export default function Button({ size, state, children, ...props }) {
-  return (
-    <StyledButton size={size} state={state} {...props}>
-      {children}
-    </StyledButton>
-  );
-}
-
 Button.propTypes = {
+  ...Button.propTypes,
   size: PropTypes.oneOf(Object.values(BUTTON_SIZE)).isRequired,
   state: PropTypes.oneOf(Object.values(BUTTON_STATE.LARGE_34)).isRequired,
-  children: PropTypes.string.isRequired,
-};
+}
+
+export default Button;

--- a/src/component/common/Button/style.jsx
+++ b/src/component/common/Button/style.jsx
@@ -1,0 +1,50 @@
+import { css } from "styled-components";
+
+const stateStyleMap = {
+  disabled: css`
+    background-color: ${({ theme }) => theme.snDisabled};
+    pointer-events: none;
+  `,
+  activated: css`
+    background-color: ${({ theme }) => theme.snWhite};
+    color: ${({ theme }) => theme.snGreyIcon};
+  `,
+};
+
+const sizeStyleMap = {
+  xs: css`
+    width: 56px;
+    height: 28px;
+    border-radius: 26px;
+  `,
+  sm: css`
+    width: 90px;
+    height: 32px;
+    border-radius: 26px;
+  `,
+  md: css`
+    width: 100px;
+    height: 34px;
+    border-radius: 32px;
+  `,
+  lg34: css`
+    width: 120px;
+    height: 34px;
+    border-radius: 30px;
+  `,
+  lg44: css`
+    width: 120px;
+    height: 44px;
+    border-radius: 44px;
+  `,
+  xl: css`
+    width: 322px;
+    height: 44px;
+    border-radius: 44px;
+  `,
+};
+
+export {
+  stateStyleMap,
+  sizeStyleMap
+}

--- a/src/constant/button_state.js
+++ b/src/constant/button_state.js
@@ -1,5 +1,27 @@
-export const BUTTON_STATE = {
+/**
+ * @enum {string}
+ */
+const DEFAULT_BUTTON_STATE = {
   DISABLED: "disabled",
   ABLED: "abled",
+};
+
+/**
+ * @enum {string}
+ */
+const LARGE_BUTTON_STATE = {
+  ...DEFAULT_BUTTON_STATE,
   ACTIVATED: "activated",
+};
+
+/**
+ * @enum {string}
+ */
+export const BUTTON_STATE = {
+  X_LARGE: DEFAULT_BUTTON_STATE,
+  LARGE_34: LARGE_BUTTON_STATE,
+  LARGE_44: DEFAULT_BUTTON_STATE,
+  MEDIUM: DEFAULT_BUTTON_STATE,
+  SMALL: DEFAULT_BUTTON_STATE,
+  X_SMALL: DEFAULT_BUTTON_STATE,
 };

--- a/src/constant/size.js
+++ b/src/constant/size.js
@@ -1,11 +1,20 @@
+/**
+ * @enum {string}
+ */
 const SIZE = {
   MEDIUM: "md",
   SMALL: "sm",
   X_SMALL: "xs",
 };
 
+/**
+ * @enum {string}
+ */
 const PROFILE_SIZE = { ...SIZE };
 
+/**
+ * @enum {string}
+ */
 const BUTTON_SIZE = {
   ...SIZE,
   LARGE_34: "lg34",


### PR DESCRIPTION
### ▪️ 무엇을 위한 PR인가요?

- [x] 기타 : Button 컴포넌트 사용성 개선

### ▪️ 기대 결과

- 지나치게 복잡했던 Button 컴포넌트를 단순화
- BUTTON_STATE 상수의 구조를 개선하여 사이즈별로 달랐던 STATE 종류에 쉽게 대응 가능

### ▪️ 전달사항

#### 사용 예시

```jsx
<Button
  size={BUTTON_SIZE.MEDIUM}
  state={BUTTON_STATE.MEDIUM.DISABLED}
  onClick={() => { }}
>
  버튼
</Button>
```

close : #26
