### PR TITLE
✨ feat: 드롭다운 컴포넌트 기본 구현

### DIFF
--- a/src/component/common/DropdownModal/Button/index.jsx
+++ b/src/component/common/DropdownModal/Button/index.jsx
@@ -1,0 +1,30 @@
+import styled from "styled-components";
+import PropTypes from "prop-types";
+
+const StyledButton = styled.button`
+  padding: 14px 26px;
+  width: 100%;
+  display: flex;
+  justify-content: flex-start;
+  margin: 0 auto;
+
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 18px;
+  font-family: inherit;
+`;
+
+export default function Button({ children, onClick }) {
+  return (
+    <li>
+      <StyledButton type="button" onClick={onClick}>
+        {children}
+      </StyledButton>
+    </li>
+  );
+}
+
+Button.propTypes = {
+  children: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired,
+};

--- a/src/component/common/DropdownModal/index.jsx
+++ b/src/component/common/DropdownModal/index.jsx
@@ -1,0 +1,104 @@
+import PropTypes from "prop-types";
+import { useRef } from "react";
+import styled from "styled-components";
+
+import Button from "./Button/index";
+
+//https://developer.mozilla.org/en-US/docs/Web/API/Touch_events/Using_Touch_Events
+//https://nohack.tistory.com/123
+//https://www.codicode.com/art/easy_way_to_add_touch_support_to_your_website.aspx
+//https://ui.toast.com/weekly-pick/ko_20220106
+
+const ModalSection = styled.section`
+  z-index: 500;
+
+  position: fixed;
+  top: 0;
+  left: 0;
+
+  width: 100vw;
+  height: 100vh;
+
+  display: flex;
+  align-items: flex-end;
+
+  background-color: rgba(0, 0, 0, 0.3);
+`;
+
+const Modal = styled.ul`
+  width: 100%;
+  background-color: ${({ theme }) => theme.snWhite};
+  border-radius: 10px 10px 0 0;
+  padding: 0 0 8px;
+  overflow: hidden;
+
+  position: relative;
+
+  .touch-bar {
+    width: 100%;
+    height: 36px;
+
+    ::before {
+      content: "";
+
+      position: absolute;
+      top: 16px;
+      left: 50%;
+      transform: translateX(-50%);
+
+      width: 50px;
+      height: 4px;
+      background-color: ${({ theme }) => theme.snGreyOff};
+      border-radius: 5px;
+    }
+  }
+
+  @keyframes growUp {
+    0% {
+      transform: scaleY(0.9);
+    }
+
+    100% {
+      transform: scaleY(1);
+    }
+  }
+
+  animation: 600ms growUp;
+  transform-origin: bottom center;
+`;
+
+export default function DropdownModal({ isDroppedUp, dropDown, children }) {
+  const modalRef = useRef(null);
+  const touchbarRef = useRef(null);
+
+  function handleModalSection(event) {
+    if (
+      event.target !== modalRef.current &&
+      event.target !== touchbarRef.current
+    ) {
+      dropDown();
+    }
+    return;
+  }
+
+  // TODO 터치기능 구현
+  return (
+    isDroppedUp && (
+      <ModalSection onClick={handleModalSection}>
+        <h2 className="sr-only">모달</h2>
+        <Modal ref={modalRef}>
+          <li className="touch-bar" ref={touchbarRef}></li>
+          {children}
+        </Modal>
+      </ModalSection>
+    )
+  );
+}
+
+DropdownModal.Button = Button;
+
+DropdownModal.propTypes = {
+  isDroppedUp: PropTypes.bool.isRequired,
+  dropDown: PropTypes.func.isRequired,
+  children: PropTypes.node.isRequired,
+};

--- a/src/constant/dropdown.js
+++ b/src/constant/dropdown.js
@@ -1,0 +1,9 @@
+const DROPDOWN = {
+  DELETE: "삭제",
+  EDIT: "수정",
+  VISIT: "웹사이트에서 상품 보기",
+  REPORT: "신고하기",
+  EXIT_CHAT: "채팅방 나가기",
+};
+
+export default DROPDOWN;

--- a/src/constant/dropdown.js
+++ b/src/constant/dropdown.js
@@ -1,9 +1,0 @@
-const DROPDOWN = {
-  DELETE: "삭제",
-  EDIT: "수정",
-  VISIT: "웹사이트에서 상품 보기",
-  REPORT: "신고하기",
-  EXIT_CHAT: "채팅방 나가기",
-};
-
-export default DROPDOWN;

--- a/src/hook/useDropdownModal.js
+++ b/src/hook/useDropdownModal.js
@@ -1,0 +1,6 @@
+import useModal from "hook/useModal";
+
+export default function useDropdownModal() {
+  const [isDroppedUp, dropUp, dropDown, _] = useModal();
+  return [isDroppedUp, dropUp, dropDown];
+}


### PR DESCRIPTION
### ▪️ 무엇을 위한 PR인가요?

- [ ] 기능 추가 : 드롭다운 컴포넌트 기본 구현

### ▪️ 전달사항

- 하단 nav의 z-index는 100입니다.
- dropdown modal section의 z-index는 500입니다.
- alert modal의 z-index는 700입니다.
- 수정이 필요한 것 같다면 알려주세요.
- 상수를 추가했습니다.
```jsx
export default function HomePage() {
  const [isDroppedUp, dropUp, dropDown] = useDropdownModal();

  function handleDeleteButton() {
    console.log("delete");
    dropDown();
  }

  function handleEditButton() {
    console.log("edit");
    dropDown();
  }

  function handleVisitButton() {
    console.log("visit");
    dropDown();
  }

  return (
    <>
      <button type="button" onClick={dropUp}>
        드롭업!
      </button>
      <DropdownModal isDroppedUp={isDroppedUp} dropDown={dropDown}>
        <DropdownModal.Button onClick={handleDeleteButton}>
          삭제
        </DropdownModal.Button>
        <DropdownModal.Button onClick={handleEditButton}>
          {DROPDOWN.EDIT}
        </DropdownModal.Button>
        <DropdownModal.Button onClick={handleVisitButton}>
          {DROPDOWN.VISIT}
        </DropdownModal.Button>
      </DropdownModal>
    </>
  );
}
```

### ▪️ Issue Number

close : #50 
