### PR TITLE
✨feat: UploadImageLabel 추가

### DIFF
--- a/src/component/common/BigProfile/UploadProfileImageLabel/index.jsx
+++ b/src/component/common/BigProfile/UploadProfileImageLabel/index.jsx
@@ -1,0 +1,26 @@
+import { forwardRef } from "react";
+import styled from "styled-components";
+
+import Icons from "asset/icon/icons";
+
+const StyledLabel = styled.label`
+  width: 36px;
+  height: 36px;
+  padding: 7px;
+
+  background-color: ${({ theme }) => theme.snBlue};
+  border-radius: 50%;
+
+  cursor: pointer;
+`
+
+const UploadProfileImageLabel = forwardRef(function ForwardedUploadProfileImageInput(_, ref) {
+  return (
+    <StyledLabel>
+      <Icons.Image title="프로필 업로드 버튼입니다." />
+      <input ref={ref} type="file" className="sr-only" accept="image/*" required />
+    </StyledLabel>
+  )
+})
+
+export default UploadProfileImageLabel;

--- a/src/component/common/BigProfile/index.jsx
+++ b/src/component/common/BigProfile/index.jsx
@@ -2,6 +2,7 @@ import styled, { css } from "styled-components";
 import PropTypes from "prop-types";
 
 import ProfileErrorImage from "asset/logo-404-203220.png";
+import UploadProfileImageLabel from "./UploadProfileImageLabel";
 
 const Wrapper = styled.div`
   display: flex;
@@ -90,3 +91,5 @@ BigProfile.propTypes = {
   bottomRight: PropTypes.element,
   isPhotographer: PropTypes.bool,
 };
+
+BigProfile.UploadLabel = UploadProfileImageLabel;


### PR DESCRIPTION
### ▪️ 무엇을 위한 PR인가요?

- [x] 기능 추가 : BigProfile에서 사용할 수 있는 이미지 업로드용 라벨 개발

### ▪️ 전달사항

- BigProfile.UplaodLabel로 접근할 수 있으며, forwordRef로 감싸져 있어 useRef로 데이터를 가져올 수 있습니다. label로 input[type="file"]을 감싸고 있는 형태로, 따로 input 요소를 생각할 필요가 없습니다.

### 스크린샷

![image](https://user-images.githubusercontent.com/87423085/209580670-d35dcb40-ed5b-4893-a96a-3d82798a9364.png)


### ▪️ Issue Number

close : #57